### PR TITLE
Don't depend upon wikimedia/timestamp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
 	"require": {
 		"composer/installers": "1.*,>=1.0.1",
 		"pear/mail_mime": "1.*,>=1.10.1",
-		"phpoffice/phpexcel": "^1.8",
-		"wikimedia/timestamp": "1.*"
+		"phpoffice/phpexcel": "^1.8"
 	},
 	"require-dev": {
 		"jakub-onderka/php-parallel-lint": "0.9.2",


### PR DESCRIPTION
It's provided by MediaWiki core, so extensions don't need to explicitly depend
upon it.